### PR TITLE
Try to fix .dockerignore for Docker Hub usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,5 @@
-# Ignore everything
-**
-
-# Allow files and directories which are required for base image
-!./benchmarks/**
-!./configs/**
-!./C-Hayai/**
-!./tools/**
-
-!./requirements.R
+# Ignore some folders which do not contain releveant data
+./.idea/**
+./paper/**
+./docker/**
+./docs/**


### PR DESCRIPTION
It's weired, but probably Docker Hub does not support the exclude all as expected.

This solution is suboptimal compared to the previous file, but getting it working
is more important after all.